### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.0.4 (released 2018-08-14)
+
+- Bumps pytest minimun version to 3.8.0.
+
 Version 1.0.3 (released 2018-09-05)
 
 - Moves module dependent imports inside the fixture functions in order to

--- a/pytest_invenio/version.py
+++ b/pytest_invenio/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_requires = [
 
 install_requires = [
     'pytest-flask>=0.10.0',
-    'pytest>=3.3.0',
+    'pytest>=3.8.0',
     'selenium>=3.7.0',
 ]
 


### PR DESCRIPTION
I think the previous release, 1.0.3, didn’t go through because of the pytest version.
It was a timing issue I guess, we merged the PR around the same time they release a new version of pytest-flask.
Should we do something about 1.0.3?