### PR TITLE
bug: scope fix for pytest 3.8.1

### DIFF
--- a/pytest_invenio/plugin.py
+++ b/pytest_invenio/plugin.py
@@ -2,6 +2,8 @@
 #
 # This file is part of pytest-invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2018 Northwestern University, Feinberg School of Medicine,
+# Galter Health Sciences Library.
 #
 # pytest-invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -52,7 +54,9 @@ def pytest_generate_tests(metafunc):
 
         # Parameterize test based on list of browsers.
         browsers = os.environ.get('E2E_WEBDRIVER_BROWSERS', 'Chrome').split()
-        metafunc.parametrize('browser', browsers, indirect=True)
+        metafunc.parametrize(
+            'browser', browsers, indirect=True, scope='function'
+        )
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,8 @@
 #
 # This file is part of pytest-invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2018 Northwestern University, Feinberg School of Medicine,
+$ Galter Health Sciences Library.
 #
 # pytest-invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,6 +17,6 @@ check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 # Following is needed in order to get proper code coverage for pytest plugins.
 # See https://pytest-cov.readthedocs.io/en/latest/plugins.html
-COV_CORE_SOURCE=pytest_invenio COV_CORE_CONFIG=.coveragerc COV_CORE_DATAFILE=.coverage.eager py.test --cov=pytest_invenio
+COV_CORE_SOURCE=pytest_invenio COV_CORE_CONFIG=.coveragerc COV_CORE_DATAFILE=.coverage.eager pytest --cov=pytest_invenio
 # Run twice to get proper test coverage results
-COV_CORE_SOURCE=pytest_invenio COV_CORE_CONFIG=.coveragerc COV_CORE_DATAFILE=.coverage.eager py.test --cov=pytest_invenio
+COV_CORE_SOURCE=pytest_invenio COV_CORE_CONFIG=.coveragerc COV_CORE_DATAFILE=.coverage.eager pytest --cov=pytest_invenio

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 # This file is part of pytest-invenio.
 # Copyright (C) 2017-2018 CERN.
 # Copyright (C) 2018 Esteban J. G. Garbancho.
+# Copyright (C) 2018 Northwestern University, Feinberg School of Medicine,
+# Galter Health Sciences Library.
 #
 # pytest-invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -49,7 +51,7 @@ setup_requires = [
 
 install_requires = [
     'pytest-flask>=0.10.0',
-    'pytest>=3.8.0',
+    'pytest>=3.8.1',
     'selenium>=3.7.0',
 ]
 


### PR DESCRIPTION
Hello,

pytest 3.8.1 fixed some scoping issues, but this caused 

```python
def pytest_generate_tests(metafunc):
    # ...
    metafunc.parametrize('browser', browsers, indirect=True)
```
to generate a *session* scoped parametrized test. The following hook 

```python
@pytest.hookimpl(tryfirst=True, hookwrapper=True)
def pytest_runtest_makereport(item, call):
```

was then just run once the session was torndown (or at least not at the right moment). 

```python
def _take_screenshot_if_test_failed(browser, request): ...
```
would throw `AttributeError: 'Session' object has no attribute 'rep_call'` because `item` was never set the `rep`.

Long story short, `metafunc.parametrize('browser', browsers, indirect=True, scope='function')` fixes it.

Side note, the test suite is broken for Elasticsearch 6.