### PR TITLE
Fix default app config CSP value

### DIFF
--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -148,6 +148,7 @@ def app_config(db_uri, broker_uri, celery_config):
     return dict(
         APP_DEFAULT_SECURE_HEADERS=dict(
             force_https=False,
+            content_security_policy={'default-src': []}
         ),
         # Broker configuration
         BROKER_URL=broker_uri,


### PR DESCRIPTION
After [this change in invenio-app](https://github.com/inveniosoftware/invenio-app/commit/1aa6bb95b94c77b79c8bbfd448582f68bf52a686) the test app needs to init the `content_security_policy` dict value, otherwise it fails with:

```
if app.config['DEBUG']:
            app.config['APP_DEFAULT_SECURE_HEADERS'][
>               'content_security_policy']['default-src'] += \
                flask_talisman_debug_mode
E           KeyError: 'content_security_policy'

../modules/invenio-app/invenio_app/ext.py:65: KeyError
```