### PR TITLE
Fix fixture name

### DIFF
--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -105,9 +105,9 @@ def _celery_config():
     default Invenio Celery configuration.
     """
     default_config = dict(
-        CELERY_ALWAYS_EAGER=True,
+        CELERY_TASK_ALWAYS_EAGER=True,
         CELERY_CACHE_BACKEND='memory',
-        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        CELERY_TASK_EAGER_PROPAGATES_EXCEPTIONS=True,
         CELERY_RESULT_BACKEND='cache',
     )
 
@@ -126,8 +126,8 @@ def _celery_config():
     return inner
 
 
-celery_config = pytest.fixture(
-    scope='module', name='celery_config')(_celery_config())
+celery_config_ext = pytest.fixture(
+    scope='module', name='celery_config_ext')(_celery_config())
 """Celery configuration (defaults to eager tasks).
 
 Scope: module
@@ -142,14 +142,14 @@ overwritten in a specific test module:
     import pytest
 
     pytest.fixture(scope='module')
-    def celery_config(celery_config):
-        celery_config['CELERY_ALWAYS_EAGER'] = False
-        return celery_config
+    def celery_config_ext(celery_config_ext):
+        celery_config_ext['CELERY_TASK_ALWAYS_EAGER'] = False
+        return celery_config_ext
 """
 
 
 @pytest.fixture(scope='module')
-def app_config(db_uri, broker_uri, celery_config):
+def app_config(db_uri, broker_uri, celery_config_ext):
     """Application configuration fixture.
 
     Scope: module
@@ -197,7 +197,7 @@ def app_config(db_uri, broker_uri, celery_config):
         # Disable CRSF protection in WTForms
         WTF_CSRF_ENABLED=False,
         # Celery configuration
-        **celery_config
+        **celery_config_ext
     )
 
 

--- a/pytest_invenio/plugin.py
+++ b/pytest_invenio/plugin.py
@@ -25,9 +25,9 @@ import os
 import pytest
 
 from .fixtures import _monkeypatch_response_class, app, app_config, appctx, \
-    base_app, base_client, broker_uri, browser, celery_config, cli_runner, \
-    database, db, db_uri, default_handler, es, es_clear, instance_path, \
-    mailbox, script_info
+    base_app, base_client, broker_uri, browser, celery_config_ext, \
+    cli_runner, database, db, db_uri, default_handler, es, es_clear, \
+    instance_path, mailbox, script_info
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -86,7 +86,7 @@ def test_app_config(testdir):
             assert app_config['SQLALCHEMY_DATABASE_URI'] == db_uri
             assert app_config['BROKER_URL'] == broker_uri
             assert app_config['SECRET_KEY'] == 'test-secret-key'
-            assert app_config['CELERY_ALWAYS_EAGER'] == True
+            assert app_config['CELERY_TASK_ALWAYS_EAGER'] == True
     """)
     # Test that application fixture can be overwritten in each module.
     testdir.makepyfile(test_app_overwrite="""
@@ -379,13 +379,14 @@ def test_browser(conftest_testdir, monkeypatch):
     monkeypatch.undo()
 
 
-def test_celery_config(testdir):
+def test_celery_config_ext(testdir):
     """Test celery config."""
     testdir.makepyfile(test_app="""
-        def test_celery_config_with_celery(celery_config):
-            assert celery_config['CELERY_ALWAYS_EAGER'] == True
-            assert celery_config['CELERY_CACHE_BACKEND'] == 'memory'
-            assert celery_config['CELERY_EAGER_PROPAGATES_EXCEPTIONS'] == True
-            assert celery_config['CELERY_RESULT_BACKEND'] == 'cache'
+        def test_celery_config_with_celery(celery_config_ext):
+            assert celery_config_ext['CELERY_TASK_ALWAYS_EAGER'] == True
+            assert celery_config_ext['CELERY_CACHE_BACKEND'] == 'memory'
+            assert celery_config_ext[
+            'CELERY_TASK_EAGER_PROPAGATES_EXCEPTIONS'] == True
+            assert celery_config_ext['CELERY_RESULT_BACKEND'] == 'cache'
     """)
     testdir.runpytest().assert_outcomes(passed=1)


### PR DESCRIPTION
(closes #27 )

celery config variables names change because of: 
```
warnings.py                 99 WARNING  /Users/karolina/.local/share/virtualenvs/my-site-DReFpfCV/lib/python3.6/site-packages/flask_celeryext/app.py:34: UserWarning: Celery v4 installed, but detected Celery v3 configuration CELERY_ALWAYS_EAGER (use CELERY_TASK_ALWAYS_EAGER instead).
  UserWarning

warnings.py                 99 WARNING  /Users/karolina/.local/share/virtualenvs/my-site-DReFpfCV/lib/python3.6/site-packages/flask_celeryext/app.py:34: UserWarning: Celery v4 installed, but detected Celery v3 configuration CELERY_EAGER_PROPAGATES_EXCEPTIONS (use CELERY_TASK_EAGER_PROPAGATES instead).
```