### PR TITLE
fixtures: add Invenio Cache fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Idea software family
 .idea/
+.vscode/
 
 # C extensions
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ cache:
 env:
   global:
     - E2E_OUTPUT=base64
-    - ES_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.tar.gz
+    - DOCKER_COMPOSE_VERSION=1.24.1
   matrix:
     - REQUIREMENTS=lowest
     - REQUIREMENTS=release DEPLOY=true
@@ -42,10 +42,11 @@ python:
   - "3.5"
 
 before_install:
-  # Download and start ES
-  - "mkdir /tmp/elasticsearch"
-  - "wget -O - $ES_URL | tar xz --directory=/tmp/elasticsearch --strip-components=1"
-  - "/tmp/elasticsearch/bin/elasticsearch &"
+  # Install docker-compose and start Elasticsearch + Redis
+  - "sudo rm /usr/local/bin/docker-compose"
+  - "curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose"
+  - "chmod +x docker-compose"
+  - "sudo mv docker-compose /usr/local/bin"
   # Chrome webdriver for Selenium
   - "PATH=$PATH:$HOME/webdrivers"
   - "if [ ! -f $HOME/webdrivers/chromedriver ]; then wget https://chromedriver.storage.googleapis.com/2.31/chromedriver_linux64.zip -P $HOME/webdrivers; unzip -d $HOME/webdrivers $HOME/webdrivers/chromedriver_linux64.zip; fi"
@@ -59,6 +60,8 @@ before_install:
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[all]"
+  - "docker-compose up -d"
+  - "docker-compose exec redis redis-cli ping"
 
 before_script:
   # https://docs.travis-ci.com/user/gui-and-headless-browsers/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.2.0 (released 2019-07-31)
+
+- Adds fixture for creating default Location.
+- Adds fixture for creating Bucket from directory with files.
+
 Version 1.1.1 (released 2019-05-21)
 
 - Adds pytest-cov as install dependency.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pytest-invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 #
 # pytest-invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
-
-# Docker Compose file for starting an Elasticsearch node, needed by some of the
-# tests. Starting Elasticsearch is as simple as running::
 #
-#   docker-compose up
+# Docker Compose file for starting an Elasticsearch node and Redis instance.
+# These services are needed by some of the tests. Starting the services is as
+# simple as running::
+#
+#   docker-compose up -d
 
 version: '2.2'
 services:
@@ -17,3 +18,7 @@ services:
     image: elasticsearch:5
     ports:
       - 9200:9200
+  redis:
+    image: redis:5
+    ports:
+      - 6379:6379

--- a/pytest_invenio/plugin.py
+++ b/pytest_invenio/plugin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pytest-invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 # Copyright (C) 2018 Northwestern University, Feinberg School of Medicine,
 # Galter Health Sciences Library.
 #
@@ -27,7 +27,8 @@ import pytest
 from .fixtures import _monkeypatch_response_class, app, app_config, appctx, \
     base_app, base_client, broker_uri, browser, bucket_from_dir, \
     celery_config_ext, cli_runner, database, db, db_uri, default_handler, \
-    es, es_clear, instance_path, location, mailbox, script_info
+    es, es_clear, instance_path, inv_cache, inv_cache_clear, inv_cache_flush, \
+    location, mailbox, script_info
 
 
 def pytest_generate_tests(metafunc):

--- a/pytest_invenio/version.py
+++ b/pytest_invenio/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pytest-invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 # Copyright (C) 2018 Esteban J. G. Garbancho.
 # Copyright (C) 2018 Northwestern University, Feinberg School of Medicine,
 # Galter Health Sciences Library.
@@ -32,7 +32,9 @@ tests_require = [
     'pydocstyle>=2.0.0',
     'pytest-pep8>=1.0.6',
     'six>=1.12.0',
-    'urllib3>=1.23'
+    'urllib3>=1.23,<1.25',
+    'invenio-cache>=1.0.0',
+    'redis>=3.0.0'
 ]
 
 extras_require = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of pytest-invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2019 CERN.
 #
 # pytest-invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -23,6 +23,7 @@ def conftest_testdir(testdir):
 
         from flask import Flask, jsonify, current_app
         from functools import partial
+        from invenio_cache import InvenioCache
         from invenio_db import InvenioDB
         from invenio_mail import InvenioMail
         from invenio_search import InvenioSearch
@@ -31,6 +32,7 @@ def conftest_testdir(testdir):
         def _factory(name, **config):
             app_ = Flask(name)
             app_.config.update(**config)
+            InvenioCache(app_)
             InvenioDB(app_)
             InvenioSearch(app_)
             InvenioMail(app_)


### PR DESCRIPTION
Adds three fixtures for Invenio Cache:
1. `inv_cache`
2. `inv_cache_clear`
3. `inv_cache_flush`

`inv_cache` setups a simple Invenio Cache fixture.

`inv_cache_clear` setups an Invenio Cache fixture that clears all keys with the `CACHE_KEY_PREFIX` after each test. The `CACHE_KEY_PREFIX` defaults to `cache::`.

`inv_cache_flush` setups an Invenio Cache fixture that flushes the Redis database on module teardown. 

Depends on #36 and inveniosoftware/invenio-search#180