### PR TITLE
travis: uninstall numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ before_install:
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[all]"
+  # Uninstall numpy (present by default in Travis/Python workers)
+  # as it causes side effects with elasticsearch-py
+  - pip uninstall numpy -y
+  - pip freeze
 
 script:
   - "./run-tests.sh"


### PR DESCRIPTION
* Travis workers using Python language come with numpy by default.
  This causes a side effect wich is executing code in elasticsearch-py
  which isn't meant to be executed as we don't depend on numpy
  see https://github.com/elastic/elasticsearch-py/blob/2120dff4475f19b5cc4304be325a0bdf4df2dbeb/elasticsearch/serializer.py#L22
  (closes #45).