### PR TITLE
Build v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ env:
     - REQUIREMENTS=devel
 
 python:
-  - "2.7"
-  - "3.5"
+  - "3.6"
 
 before_install:
   # Download and start ES
@@ -83,8 +82,6 @@ deploy:
   password:
     secure: "UES49TwCHOmAsSx/cuUfzWa8nrUuTtXHz/RCgz2gx1svZWavfRyNwr4E/9u9iyETUcN1n1qPwq32dFlm+nBCHI6uAHgIeVJConaNqYxp8/fAsZfLwD9CBe/K4V7nGUxeHjgkJmg3mPAkVAwHSusRZtcyvIx1CMrVc5WPh8E7H0XlHB7lw7CZ0CrShccq+uw1EwP8yXfOJrWjfY5NfIz7avNxbk0Rmxnj/ucqxI4GE6Ex19ra7w9RlQkfu7s17Ma/QYMI5JdZ29FQfUV1TV4ZHymaH+Vql85BMYxEk83pQKVx65pcoAZt28LrrzPs0kmLNVtWJbmjud26YBeLrAK3Ks2GsuNqMQFjcO1yUEdsHKbQ8cQE9n9Ifo0xYRwjx1C3kfIqUtBmeYY1M8n5sobpHECizhFtDmSFuO+Y0zSgvGgAW831jvWmIZHfspKI0Xek3KGikcvtZR4dL8WAmdF7jFrjx4cDzzhbSFO+4mHEP6DT+L7LGhxL8XnDSMjekrP3w0sPstbCL5iKcboiqi1xOud7Lxvme0mDrVze+D5kIO7V3it3coZ3Pe5LI36p9rzYSPJfRCy8tMRie8BEQP3sqOdyadWJnywJIxhSJp0SD7l2vtP9uLWuW7+97JWaGGdEHLeQHpu1x8pNf0CTEtWTKnlAykM5z6/wyPnUkBMm/Kk="
   distributions: sdist bdist_wheel
+  skip_existing: true
   on:
-    condition: $DEPLOY = true
-    python: '3.5'
-    repo: inveniosoftware/pytest-invenio
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,10 @@ before_install:
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[all]"
+  # Uninstall numpy (present by default in Travis/Python workers)
+  # as it causes side effects with elasticsearch-py
+  - pip uninstall numpy -y
+  - pip freeze
 
 before_script:
   # https://docs.travis-ci.com/user/gui-and-headless-browsers/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,16 @@
 Changes
 =======
 
+Version 1.2.2 (released 2020-05-07)
+
+- Uninstalls numpy in Travis due to incompatibilities with
+  elasticsearch-py.
+- Deprecated Python versions lower than 3.6.0. Now supporting 3.6.0.
+- Set maximum version of Werkzeug to 1.0.0 due to incompatible imports.
+- Set maximum version of Flask to 1.1.0 due to incompatible imports.
+- Set maximum version of Pytest-Flask to 1.0.0 due to breaking changes.
+- Set minimum version of Invenio-Search to 1.2.3 and maximum to 1.3.0.
+
 Version 1.2.1 (released 2019-11-13)
 
 - Fixes instance path fixture to also set the static folder.

--- a/pytest_invenio/version.py
+++ b/pytest_invenio/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/setup.py
+++ b/setup.py
@@ -20,19 +20,20 @@ history = open('CHANGES.rst').read()
 
 tests_require = [
     'check-manifest>=0.25',
-    'coverage>=4.0',
+    'coverage>=4.1',
     'elasticsearch-dsl>=5.0.0,<6.0.0',
     'elasticsearch>=5.0.0,<6.0.0',
     'flask-celeryext>=0.3.1',
     'invenio-db>=1.0.0,<1.1.0',
     'invenio-files-rest>=1.0.0',
     'invenio-mail>=1.0.0,<1.1.0',
-    'invenio-search>=1.0.0,<1.1.0',
+    'invenio-search>=1.2.3,<1.3.0',
+    'invenio-rest>=1.1.2,<1.2.0',
     'isort>=4.3',
     'pydocstyle>=2.0.0',
     'pytest-pep8>=1.0.6',
     'six>=1.12.0',
-    'urllib3>=1.23'
+    'urllib3>=1.23',
 ]
 
 extras_require = {
@@ -51,7 +52,8 @@ setup_requires = [
 ]
 
 install_requires = [
-    'pytest-flask>=0.10.0',
+    'Flask>=1.0.4,<1.1.0',
+    'pytest-flask>=0.10.0,<1.0.0',
     'pytest>=3.8.1',
     'pytest-cov>=2.5.1',
     'selenium>=3.7.0',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ install_requires = [
     'pytest>=3.8.1',
     'pytest-cov>=2.5.1',
     'selenium>=3.7.0',
+    'werkzeug>=0.14.1,<1.0.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/pytest-invenio/issues/47

Changes:

- Uninstall numpy in travis
- Upper pin Werkzeug, pytest-flask and others
- Remove python versions lower than 3.6