### PR TITLE
dependencies: move from test to install centrally managed deps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version 1.3.2 (released 2020-05-19)
+
+- Move check-manifest, coverage, isort, pydocstyle, pytest-flask and
+  pytest-pep8 from test to install requirements to provide them as centrally
+  managed dependencies.
+
 Version 1.3.1 (released 2020-05-12)
 
 - Uninstalls numpy in Travis due to incompatibilities with

--- a/pytest_invenio/version.py
+++ b/pytest_invenio/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'check-manifest>=0.25',
-    # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
-    'coverage>=4.0,<5.0.0',
     'elasticsearch-dsl>=6.0.0,<7.0.0',
     'elasticsearch>=6.0.0,<7.0.0',
     'invenio-celery>=1.2.0',
@@ -29,9 +26,6 @@ tests_require = [
     'invenio-files-rest>=1.1.1',
     'invenio-mail>=1.0.0,<1.1.0',
     'invenio-search>=1.2.3,<1.3.0',
-    'isort>=4.3',
-    'pydocstyle>=2.0.0',
-    'pytest-pep8>=1.0.6',
     'six>=1.12.0',
     'urllib3>=1.23'
 ]
@@ -54,9 +48,15 @@ setup_requires = [
 install_requires = [
     # pinned because of change of fixture scope in pytest-flask v1.0.0
     # live_server
-    'pytest-flask>=0.15.1,<1.0.0',
+    'check-manifest>=0.25',
+    # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
+    'coverage>=4.0,<5.0.0',
+    'isort>=4.3',
+    'pydocstyle>=2.0.0',
     'pytest>=4.6.1',
     'pytest-cov>=2.5.1',
+    'pytest-flask>=0.15.1,<1.0.0',
+    'pytest-pep8>=1.0.6',
     'selenium>=3.7.0',
 ]
 


### PR DESCRIPTION
To comply with https://invenio.readthedocs.io/en/latest/releases/v3.3.0.html#dependency-management and added a few more that are needed all around.

Question, should selenium be an extra? All modules test python code but not all test UI.