### PR TITLE
dependencies: upgrade isort

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     'check-manifest>=0.25',
     # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
     'coverage>=4.0,<5.0.0',
-    'isort>=4.3',
+    'isort>=5.0',
     'pydocstyle>=2.0.0',
     'pytest>=4.6.1',
     'pytest-cov>=2.5.1',


### PR DESCRIPTION
The newly released isort version (5) has some breaking changes:

- Removed `-rc`
- Added a dash to `-df`, making it `--df`.

In order to have consistency this package would bump the minimum version. The rest of the packages should update the `run-tests.sh` file.

*Open questions*:

- Should there be an upper bound to the version pin of external packages?
- When migrating external packages. Should we expand flags?
