### PR TITLE
[NEEDS DECISION] test: register pytest-celery as plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ install_requires = [
     'check-manifest>=0.42',
     'coverage>=5.3,<6',
     'docker-services-cli>=0.1.0',
-    'pytest-celery>=0.0.0a1',
     'pytest-cov>=2.10.1',
     'pytest-flask>=1.0.0',
     'pytest-isort>=1.2.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-pytest_plugins = ["pytester"]
+pytest_plugins = ["pytester", "celery.contrib.pytest",]
 
 
 @pytest.fixture()


### PR DESCRIPTION
This is for demo purposes only. To display how `celery_config` is not found at module level when registered only as pytest-plugin.

Partially closes https://github.com/inveniosoftware/cookiecutter-invenio-instance/issues/258