### PR TITLE
fixtures: add support for importlib entry points

### DIFF
--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -14,7 +14,9 @@ import shutil
 import sys
 import tempfile
 from datetime import datetime
+from unittest.mock import patch
 
+import importlib_metadata
 import pkg_resources
 import pytest
 from pytest_flask.plugin import _make_test_response_class
@@ -690,6 +692,30 @@ class MockDistribution(pkg_resources.Distribution):
         pass
 
 
+class MockImportlibDistribution(importlib_metadata.Distribution):
+    """A mocked distribution where we can inject entry points."""
+
+    def __init__(self, extra_entry_points):
+        """Entry points for the distribution."""
+        self._entry_points = extra_entry_points
+
+    @property
+    def name(self):
+        """Return the 'Name' metadata for the distribution package."""
+        return 'MockDistribution'
+
+    @property
+    def entry_points(self):
+        """Iterate over entry points."""
+        for group, eps_lines in self._entry_points.items():
+            for ep_line in eps_lines:
+                name, value = ep_line.split('=', maxsplit=1)
+                yield importlib_metadata.EntryPoint(
+                    # strip possible white space due to split on "="
+                    name=name.strip(), value=value.strip(), group=group
+                )
+
+
 @pytest.fixture(scope="module")
 def entry_points(extra_entry_points):
     """Entry points fixture.
@@ -721,19 +747,37 @@ def entry_points(extra_entry_points):
         def create_app(instance_path, entry_points):
             return _create_api
     """
+    # Create mocked distributions
+    pkg_resources_dist = MockDistribution(extra_entry_points)
+    importlib_dist = MockImportlibDistribution(extra_entry_points)
+
+    #
+    # Patch importlib
+    #
+    old_distributions = importlib_metadata.distributions
+
+    def distributions(**kwargs):
+        for dist in old_distributions(**kwargs):
+            yield dist
+        yield importlib_dist
+
+    importlib_metadata.distributions = distributions
+
+    #
+    # Patch pkg_resources
+    #
     # First make a copy of the working_set state, so that we can restore the
     # state.
     workingset_state = pkg_resources.working_set.__getstate__()
-
     # Next, make a fake distribution that will yield the extra entry points and
     # add them to the global working_set.
-    dist = MockDistribution(extra_entry_points)
-    pkg_resources.working_set.add(dist)
+    pkg_resources.working_set.add(pkg_resources_dist)
 
-    yield dist
+    yield pkg_resources_dist
 
-    # Last, we restore the original workingset state.
+    # Last, we restore the original workingset state and old importlib.
     pkg_resources.working_set.__setstate__(workingset_state)
+    importlib_metadata.distributions = old_distributions
 
 
 @pytest.fixture(scope="module")

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ install_requires = [
     'pytest-pydocstyle>=2.2.0',
     'pytest>=6,<7',
     'selenium>=3.7.0',
+    # Keep importlib aligned with invenio-base.
+    'importlib-metadata>=4.4',
+    'importlib-resources>=5.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* The entry points fixture is now able to also mock entry points of
  importlib-metadata. Note that importlib-metadata is the PyPI package
  and not the standard library distribution.