### PR TITLE
Bump dependency `coverage`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     check-manifest>=0.42
-    coverage>=5.3,<6
+    coverage>=5.3,<8
     docker-services-cli>=0.4.0
     pytest-cov>=3.0.0
     pytest-flask>=1.2.0


### PR DESCRIPTION
The changelog for v6 and v7 don't mention anything that seem too relevant for us.