### PR TITLE
release: v2.2.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.2.1 (released 2024-06-27)
+
+- installation: pin importlib-metadata ``<8.0.0``
+
 Version 2.2.0 (released 2024-02-28)
 
 - setup: bump coverage package

--- a/pytest_invenio/__init__.py
+++ b/pytest_invenio/__init__.py
@@ -499,6 +499,6 @@ information.
 """
 
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __all__ = ("__version__",)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     pytest-pycodestyle>=2.2.0
     pytest>=6,<7.2.0
     selenium>=3.7.0,<4
-    importlib-metadata>=4.4
+    importlib-metadata>=4.4,<8.0.0
     importlib-resources>=5.0
 
 [options.extras_require]


### PR DESCRIPTION
importlib-metadata released a major (8.0.0) that breaks our CI. 


https://github.com/python/importlib_metadata/releases/tag/v8.0.0