### PR TITLE
setup: bump selenium dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pytest-pydocstyle>=2.2.3
     pytest-pycodestyle>=2.2.0
     pytest>=6,<9.0.0
-    selenium>=3.7.0,<5
+    selenium>=4,<5
     importlib-metadata>=4.4,<8.0.0
     importlib-resources>=5.0
 


### PR DESCRIPTION
Similar to https://github.com/inveniosoftware/flask-iiif/pull/101, using `uv` sometimes brings warnings about invalid escape sequences in selenium webdriver code.
This doesn't seem to be happening in later versions of selenium.

Also, the list of breaking changes for Python in Selenium v4 doesn't seem scary for us: https://www.selenium.dev/documentation/webdriver/troubleshooting/upgrade_to_selenium_4/

---

Excerpt from our test pipeline:
```
 Container docker_services_cli-rabbitmq-1  Started
 Container docker_services_cli-opensearch-1  Started
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py:346: SyntaxWarning: invalid escape sequence '\_'
  """Finds an element by id.
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py:363: SyntaxWarning: invalid escape sequence '\_'
  """
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py:617: SyntaxWarning: invalid escape sequence '\*'
  """
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webdriver.py:639: SyntaxWarning: invalid escape sequence '\*'
  """
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webelement.py:162: SyntaxWarning: invalid escape sequence '\_'
  """Finds element within this element's children by ID.
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/remote/webelement.py:179: SyntaxWarning: invalid escape sequence '\_'
  """Finds a list of elements within this element's children by ID.
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/firefox/firefox_profile.py:208: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
  if setting is None or setting is '':
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/chrome/options.py:119: SyntaxWarning: invalid escape sequence '\*'
  """
/home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw/.venv/lib/python3.12/site-packages/selenium/webdriver/support/wait.py:28: SyntaxWarning: invalid escape sequence '\ '
  """Constructor, takes a WebDriver instance and timeout in seconds.
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.1.3, pluggy-1.5.0
rootdir: /home/gitlab-runner/builds/hiTEszfZJ/0/crdm/invenio-config-tuw, configfile: pyproject.toml, testpaths: tests, invenio_config_tuw
plugins: Faker-37.1.0, cov-6.0.0, black-0.6.0, invenio-2.2.1, mock-3.14.0, ruff-0.4.1, flask-1.3.0, github-actions-annotate-failures-0.3.0, pydocstyle-2.4.0, pycodestyle-2.4.1, isort-4.0.0
collected 182 items
```

I would like to remove some unnecessary noise to make focusing on the relevant output easier :sweat_smile: 