### PR TITLE
fix cache usage

### DIFF
--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -180,7 +180,7 @@ def search_hosts():
 
 
 @pytest.fixture(scope="module")
-def app_config(db_uri, broker_uri, celery_config_ext, search_hosts):
+def app_config(db_uri, broker_uri, celery_config_ext, search_hosts, cache_uri):
     """Application configuration fixture.
 
     Scope: module
@@ -230,6 +230,9 @@ def app_config(db_uri, broker_uri, celery_config_ext, search_hosts):
         ),
         # Broker configuration
         BROKER_URL=broker_uri,
+        # Cache configuration
+        CACHE_REDIS_URL=cache_uri,
+        ACCOUNTS_SESSION_REDIS_URL=cache_uri,
         # Disable Flask-DebugToolbar if installed.
         DEBUG_TB_ENABLED=False,
         # Disable mail sending.

--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -122,7 +122,7 @@ def _celery_config():
         CELERY_TASK_ALWAYS_EAGER=True,
         CELERY_CACHE_BACKEND="memory",
         CELERY_TASK_EAGER_PROPAGATES_EXCEPTIONS=True,
-        CELERY_RESULT_BACKEND="cache",
+        CELERY_RESULT_BACKEND="rpc://",
     )
 
     try:
@@ -230,6 +230,7 @@ def app_config(db_uri, broker_uri, celery_config_ext, search_hosts, cache_uri):
         ),
         # Broker configuration
         BROKER_URL=broker_uri,
+        CELERY_BROKER_URL=broker_uri,  # For Celery 4
         # Cache configuration
         CACHE_REDIS_URL=cache_uri,
         ACCOUNTS_SESSION_REDIS_URL=cache_uri,


### PR DESCRIPTION
- **fixtures: use `cache_uri` in `app_config`**
  * The `cache_uri` fixture is now used as `CACHE_REDIS_URL` in the
    `app_config` fixture.
  

- **fixtures: use "rpc://" result backend for Celery and fix config vars**
  