### PR TITLE
installation: pin snowballstemmer to <3.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     pytest-flask>=1.2.0
     pytest-github-actions-annotate-failures>=0.2.0
     pytest-isort>=3.0.0
+    snowballstemmer>=2.2.0,<3  # NOTE: Necessary for the unmaintained pydocstyle to work
     pytest-pydocstyle>=2.2.3
     pytest-pycodestyle>=2.2.0
     pytest>=6,<9.0.0


### PR DESCRIPTION
* `snowballstemmer` is dependency of the deprecated/unmaintained
  `pydocstyle` module. The v3.0.0 release of `snowballstemmer`
  introduces a breaking change.
