### PR TITLE
Argument for webdriver updated to Selenium 3.8.0

### DIFF
--- a/pytest_invenio/fixtures.py
+++ b/pytest_invenio/fixtures.py
@@ -716,7 +716,7 @@ def browser(request):
 
         options = Options()
         options.add_argument("--headless")
-        driver = getattr(webdriver, browser_name)(chrome_options=options)
+        driver = getattr(webdriver, browser_name)(options=options)
     else:
         driver = getattr(webdriver, browser_name)()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     pytest-pydocstyle>=2.2.3
     pytest-pycodestyle>=2.2.0
     pytest>=6,<9.0.0
-    selenium>=3.7.0,<5
+    selenium>=3.8.0,<5
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
### Description

As shown in #133 and linked [here](https://github.com/SeleniumHQ/selenium/blob/28839eee4ba9e9ab851d0baaf005696dc06f7540/py/CHANGES#L1004), from Selenium version 3.8.0 the deprecated `<browser>_options` parameters are no more supported and have been replaced with just `options`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
